### PR TITLE
Fix example code in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Opened.files(paths,
     if (error) throw error;
     paths.forEach(
       function(path) {
-        console.log(path + ' open=' + hashTable.hasOwnProperty(path));
+        console.log(path + ' open=' + hashTable[path]);
       }
     );
   }

--- a/README.md
+++ b/README.md
@@ -12,8 +12,14 @@ npm install @ronomon/opened
 ## Unix
 `Opened` uses `lsof` on macOS and on Linux. On Linux (but not on macOS), `lsof` requires sudo permissions to iterate across open file descriptors for the user, otherwise no files will be detected as open and no permissions error will be returned.
 
-## Usage
+## API
+`Opened.file()`
+Return a Boolean: `true` if the file is open, else `false`.
 
+`Opened.files()`
+Return an Object like `{ 'path_1': true, 'path_2': false, ... }`.
+
+## Usage
 ```javascript
 var Opened = require('@ronomon/opened');
 var paths = [...];

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Unix.file = function(path, end) {
   self.files([path],
     function(error, files) {
       if (error) return end(error);
-      end(undefined, files.hasOwnProperty(path));
+      end(undefined, files[path]);
     }
   );
 };


### PR DESCRIPTION
Your example code does not works in my Mac (High Sierra and node v8.6.0):
```
var Opened = require('@ronomon/opened');
var paths = ['./test.txt'];
Opened.files(paths,
  function(error, hashTable) {
    if (error) throw error;
    paths.forEach(
      function(path) {
        console.log(path + ' open=' + hashTable.hasOwnProperty(path));
      }
    );
  }
);
```

`hashTable` contain `{ 'test.txt': true|false }` so you should use:
```
console.log(path + ' open=' + hashTable[path]);
```

In place of:
```
console.log(path + ' open=' + hashTable.hasOwnProperty(path));
```

---

I've too:
- add an API section to the README to explain what is returned from `.file()` or `.files()`.
- fix a bug with `.file()` on Unix systems